### PR TITLE
Add info and doc templates for derp2.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,9 @@
+#lang info
+(define collection "derp2")
+(define deps '("base"
+               "rackunit-lib"))
+(define build-deps '("scribble-lib" "racket-doc"))
+(define scribblings '(("scribblings/derp2.scrbl" ())))
+(define pkg-desc "Description Here")
+(define version "0.0")
+(define pkg-authors '(might))

--- a/scribblings/derp2.scrbl
+++ b/scribblings/derp2.scrbl
@@ -1,0 +1,10 @@
+#lang scribble/manual
+@require[@for-label[derp2
+                    racket/base]]
+
+@title{Derp2}
+@author{Matthew Might}
+
+@defmodule[derp2]
+
+Package Description Here


### PR DESCRIPTION
Just a template you can use for adding info.rkt and scribblings (for documentation).
